### PR TITLE
Update Geocodable to use Decimal rather than Float

### DIFF
--- a/code/Geocodable.php
+++ b/code/Geocodable.php
@@ -8,8 +8,8 @@
 class Geocodable extends DataExtension {
 
 	public static $db = array(
-		'Lat' => 'Float',
-		'Lng' => 'Float'
+		'Lat' => 'Decimal',
+		'Lng' => 'Decimal'
 	);
 
 	public function onBeforeWrite() {


### PR DESCRIPTION
This pull request is partially question. I don't really have any experience with PostgreSQL but I have a travis test that fails with that DB. MySQL passes and when checking PostgreSQL [Numeric Types](http://www.postgresql.org/docs/9.1/static/datatype-numeric.html) float isn't listed but decimal is. In the [SilverStripe Docs](http://doc.silverstripe.org/en/developer_guides/model/data_types_and_casting/#available-types), ```Decimal``` is also listed while ```Float``` is left out (although it is still an available Data Type). I figured I'd do a pull request in case it is a better fit across both DB's, if not feel free to close it.