### PR TITLE
postcode regex through config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Page:
 
 
 In order to then render the full address into a template, you can use either
-`$FullAddress` to return a simple string, or `$FullAddressHTML` to render
+`$FullAddress` to return a simple string or `$FullAddressHTML` to render
 the address into a HTML `<address>` tag.
 
 You can define a global set of allowed states or countries using
@@ -62,3 +62,8 @@ GoogleGeocoding:
   google_api_key: {your_google_server_api_key}
   
 ```
+
+Allow different postcode regex (e.g. UK postcode with numbers and letters mixed) in config.yml
+```yml
+Addressable:
+  set_postcode_regex: '/^[0-9A-Za-z]+$/'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Page:
 
 
 In order to then render the full address into a template, you can use either
-`$FullAddress` to return a simple string or `$FullAddressHTML` to render
+`$FullAddress` to return a simple string, or `$FullAddressHTML` to render
 the address into a HTML `<address>` tag.
 
 You can define a global set of allowed states or countries using

--- a/code/Addressable.php
+++ b/code/Addressable.php
@@ -11,7 +11,7 @@ class Addressable extends DataExtension {
 
 	protected static $allowed_states;
 	protected static $allowed_countries;
-	protected static $postcode_regex= '/^[0-9]+$/';
+	protected static $postcode_regex = '/^[0-9]+$/';
 
 	protected $allowedStates;
 	protected $allowedCountries;
@@ -67,6 +67,9 @@ class Addressable extends DataExtension {
 	public function __construct() {
 		$this->allowedStates    = self::$allowed_states;
 		$this->allowedCountries = self::$allowed_countries;
+        if (!empty($customRegex = Config::inst()->get('Addressable', 'set_postcode_regex'))) {
+            $this->set_postcode_regex($customRegex);
+        }
 		$this->postcodeRegex    = self::$postcode_regex;
 
 		parent::__construct();

--- a/code/Addressable.php
+++ b/code/Addressable.php
@@ -68,7 +68,7 @@ class Addressable extends DataExtension {
 		$this->allowedStates    = self::$allowed_states;
 		$this->allowedCountries = self::$allowed_countries;
         if (!empty($customRegex = Config::inst()->get('Addressable', 'set_postcode_regex'))) {
-            $this->set_postcode_regex($customRegex);
+            self::set_postcode_regex($customRegex);
         }
 		$this->postcodeRegex    = self::$postcode_regex;
 


### PR DESCRIPTION
Hi, as I need to use this module with a UK postcode (that includes letters) I thought it might be helpful to set the regex through the config.yml.. so it can be set outside the module.