### PR TITLE
Enable or disable Geocode feature

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,3 +3,6 @@ name: Addressable
 GoogleGeocoding:
   google_api_url: 'https://maps.googleapis.com/maps/api/geocode/xml'
   google_api_key: ''
+
+Geocodable:
+  is_geocodable: true

--- a/code/Geocodable.php
+++ b/code/Geocodable.php
@@ -14,7 +14,11 @@ class Geocodable extends DataExtension {
 
 	public function onBeforeWrite() {
 		if (!$this->owner->isAddressChanged()) return;
-
+        /*
+         * Enable/Disable Geocode mapping
+         */
+        $isGeocodable = Config::inst()->get('Geocodable', 'is_geocodable');
+        if ($isGeocodable) {
 		$address = $this->owner->getFullAddress();
 		$region  = strtolower($this->owner->Country);
 
@@ -24,6 +28,7 @@ class Geocodable extends DataExtension {
 
 		$this->owner->Lat = $point['lat'];
 		$this->owner->Lng = $point['lng'];
+        }
 	}
 
 	public function updateCMSFields(FieldList $fields) {


### PR DESCRIPTION
This update gives users the ability so that they can enable/disable the Geocode  feature.When `is_geocodable: false`, users can manually add GeoCode.

 