### PR TITLE
fix(Geocodable): Stop truncation of last 2 decimal points. 

### DIFF
--- a/code/Geocodable.php
+++ b/code/Geocodable.php
@@ -10,8 +10,8 @@ class Geocodable extends DataExtension
 {
 
     private static $db = array(
-        'Lat' => 'Decimal(9,5)',
-        'Lng' => 'Decimal(9,5)'
+        'Lat' => 'Decimal(10,7)',
+        'Lng' => 'Decimal(10,7)'
     );
 
     public function onBeforeWrite()


### PR DESCRIPTION
Stop truncation of last 2 decimal points. 1st parameter of Decimal() was only bumped up by 1 as the maximum amount of left decimal numbers ot Lat/Lng is 3. This was tested with a DB populated with Lng/Lat values.

