### PR TITLE
fix(EmptyResponse): If the response is empty, avoid parsing with XML.

### DIFF
--- a/code/GoogleGeocoding.php
+++ b/code/GoogleGeocoding.php
@@ -26,6 +26,10 @@ class GoogleGeocoding {
 			'region'  => $region,
 			'key'		=> $key
 		));
+		if (!$service->request()->getBody()) {
+			// If blank response, ignore to avoid XML parsing errors.
+			return false;
+		}
 		$response = $service->request()->simpleXML();
 
 		if ($response->status != 'OK') {


### PR DESCRIPTION
fix(EmptyResponse): If the response is empty, avoid parsing with XML as it will throw an exception.