### PR TITLE
feat(GoogleGeocoding): Add error messages on status code 500

### DIFF
--- a/code/GoogleGeocoding.php
+++ b/code/GoogleGeocoding.php
@@ -26,6 +26,15 @@ class GoogleGeocoding {
 			'region'  => $region,
 			'key'		=> $key
 		));
+		if ($service->request()->getStatusCode() === 500) {
+			$errorMessage = '500 status code, Are you sure your SSL certificates are properly setup? You can workaround this locally by setting CURLOPT_SSL_VERIFYPEER to "false", however this is not recommended for security reasons.';
+			if (Director::isDev()) {
+				throw new Exception($errorMessage);
+			} else {
+				user_error($errorMessage);
+			}
+			return false;
+		}
 		if (!$service->request()->getBody()) {
 			// If blank response, ignore to avoid XML parsing errors.
 			return false;


### PR DESCRIPTION
Add error messages on status code 500. Took a bit of debugging to find out this usually means that your SSL stuff isn't setup properly.